### PR TITLE
fix image cross-origin issue

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -36,6 +36,7 @@ class BackgroundProcessing {
   async loadImage(src) {
     return new Promise(resolve => {
       var img = document.createElement('img');
+      img.crossOrigin = "anonymous";
       img.onerror = function(e) {
         resolve(null);
       };


### PR DESCRIPTION
In the Chrome 70, if the img tag does not set `crossorgin` attribute, chrome extension will throw cross-origin exception.

The exception looks like:
`Uncaught DOMException: Failed to execute 'texImage2D' on 'WebGL2RenderingContext': The image element contains cross-origin data, and may not be loaded.`

